### PR TITLE
Corrected typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ False
 
 -   No type conversion takes place before comparison.
 
-### Type onversion
+### Type Conversion
 
 #### Implicit conversion
 


### PR DESCRIPTION
I've change the typing mistake from previous commit.
From `Type onversion` to `Type Conversion`